### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -11,6 +11,9 @@ jobs:
   autoupdate:
     name: autoupdate
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: docker://chinthakagodawita/autoupdate-action:v1
         env:


### PR DESCRIPTION
Potential fix for [https://github.com/NicolasReyrolle/demo-data/security/code-scanning/1](https://github.com/NicolasReyrolle/demo-data/security/code-scanning/1)

To address this issue, add an explicit `permissions` block to the job or at the workflow root in `.github/workflows/autoupdate.yml`. This block should specify the minimal permissions required for the action. Based on the action `chinthakagodawita/autoupdate-action`, which typically needs access to update branches and possibly create/update pull requests, a reasonable minimal permission set is:
- `contents: write` (for pushing changes)
- `pull-requests: write` (if updating PRs)

The change should be made just before the `steps:` block within the `autoupdate` job (line 14), or immediately under the workflow name if you wish to apply the permissions to all jobs (but here best to do per-job for clarity). No other files or regions need changing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
